### PR TITLE
feat: Side navigation components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^4.1.0",
         "path": "^0.12.7",
         "react": "^18.3.1",
+        "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
         "react-query": "^3.39.3",
@@ -2937,6 +2938,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2952,6 +2959,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -3007,14 +3024,12 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4637,6 +4652,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -4768,7 +4792,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -5766,6 +5789,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-escaper": {
@@ -9257,6 +9289,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.2.tgz",
+      "integrity": "sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -10649,6 +10695,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
+      }
     },
     "node_modules/unload": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^4.1.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-query": "^3.39.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "@src/router";
 import { AuthProvider } from "@src/contexts/AuthProvider";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { CookiesProvider } from "react-cookie";
 
 function App() {
   const queryClient = new QueryClient();
@@ -9,9 +10,11 @@ function App() {
   return (
     <>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <RouterProvider router={router} />
-        </AuthProvider>
+        <CookiesProvider defaultSetOptions={{ path: "/" }}>
+          <AuthProvider>
+            <RouterProvider router={router} />
+          </AuthProvider>
+        </CookiesProvider>
       </QueryClientProvider>
     </>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@
  */
 function Footer() {
   return (
-    <footer className="mt-auto bg-brand-primary-400 h-100px flex justify-center flex-items-center w-100vw mb-0 border-t-1px border-brand border-t-solid">
+    <footer className="mt-10 flex-grow-0 flex-shrink-0 flex-basis-0 flex-basis-100px bg-brand-primary-400 h-100px flex justify-center flex-items-center border-t-1px border-brand border-t-solid">
       <p className="font-primary font-regular font-size-normal">
         Copyright ⓒ {new Date().getFullYear()}
       </p>

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,11 +1,13 @@
-import { useAuth } from "@src/hooks/useAuth";
-import classNames from "classnames";
 import NoteFunctions from "@components/NoteFunctions";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 interface Props {
-  position?: "sticky" | "relative";
   openModal?: () => void;
   renderNoteFunctions?: boolean;
+  sideNaveToggleIcon?: boolean;
+  openSideNav?: () => void;
+  sideNavOpen?: boolean;
 }
 /**
  * return the heading element
@@ -13,31 +15,31 @@ interface Props {
  * @returns the heading as jsx element
  */
 function Heading({
-  position = "relative",
   openModal,
   renderNoteFunctions = true,
+  sideNaveToggleIcon = false,
+  openSideNav,
+  sideNavOpen,
 }: Props) {
-  const { logoutUser } = useAuth();
-
-  function handleClickLogout() {
-    logoutUser();
-  }
-
-  const cx = classNames(position, { "top-0 z-1": position === "sticky" });
-
   return (
     <header
-      className={`${cx} color-brand bg-brand-primary-400 flex flex-col justify-start h-150px w-100vw border-b-1px border-brand border-b-solid`}
+      className={
+        "sticky top-0 z-10 flex-grow-0 flex-shrink-1 flex-basis-auto color-brand bg-brand-primary-400 flex flex-col justify-start border-b-1px border-brand border-b-solid"
+      }
     >
       <div className="flex">
         <h1 className="font-title font-bold font-size-title m-0 p-20px">
           Notify
         </h1>
-        <button className="" onClick={handleClickLogout}>
-          <p>logout</p>
-        </button>
       </div>
 
+      {sideNaveToggleIcon && !sideNavOpen && (
+        <FontAwesomeIcon
+          className="cursor-pointer absolute left-20px bottom-20px hover:text-brand-secundary-300"
+          icon={faBars}
+          onClick={openSideNav}
+        />
+      )}
       {renderNoteFunctions && <NoteFunctions openModal={openModal} />}
     </header>
   );

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -11,7 +11,7 @@ import {
   faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
 import Button from "./ui/Button";
-import Border from "./ui/branding/Border";
+import Border from "./ui/Border";
 import AlertModal from "./modal/AlertModal";
 
 /**

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -8,7 +8,7 @@ import {
 import { faSquare } from "@fortawesome/free-regular-svg-icons";
 import { NoteRow } from "@src/types";
 import { useNotes } from "@src/hooks/useNotes";
-import Border from "./ui/branding/Border";
+import Border from "./ui/Border";
 
 interface Props {
   note: NoteRow;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,90 @@
+import {
+  faGear,
+  faNoteSticky,
+  faPowerOff,
+  faThumbTack,
+  faThumbtackSlash,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { useAuth } from "@hooks/useAuth";
+import NavItem from "./ui/NavItem";
+import Border from "./ui/Border";
+import classNames from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface Props {
+  isOpen: boolean;
+  closeNav: () => void;
+  setDefaultSideNavOpenState: () => void;
+  defaultSideNavOpenState: boolean;
+}
+
+function Sidebar({
+  isOpen,
+  closeNav,
+  defaultSideNavOpenState,
+  setDefaultSideNavOpenState,
+}: Props) {
+  /**HOOKS */
+  const { logoutUser } = useAuth();
+
+  /**STYLING */
+  const navStyle = classNames(
+    "z-20",
+    "fixed",
+    "h-100vh",
+    "transition-width-300",
+    "bg-brand-primary-400",
+    { "w-0": !isOpen },
+    { "w-200px": isOpen }
+  );
+
+  const navMenuDivStyle = classNames("flex", "justify-end", "gap-2", "p-20px");
+  const navIconStyle = classNames(
+    "cursor-pointer",
+    "hover:text-brand-secundary-300",
+    "h-20px",
+    "w-20px"
+  );
+  const itemDivStyle = classNames(
+    "w-15rem",
+    "p-5",
+    "decoration-none",
+    "flex",
+    "flex-col",
+    "flex-items-start",
+    "gap-4"
+  );
+
+  /**COMPONENT LOGIC */
+
+  return (
+    <div className={navStyle}>
+      <Border borderRadius={false}>
+        <div className={navMenuDivStyle}>
+          <FontAwesomeIcon
+            onClick={setDefaultSideNavOpenState}
+            className={navIconStyle}
+            icon={defaultSideNavOpenState ? faThumbtackSlash : faThumbTack}
+          />
+          <FontAwesomeIcon
+            onClick={closeNav}
+            className={navIconStyle}
+            icon={faXmark}
+          />
+        </div>
+        <div className={itemDivStyle}>
+          <NavItem icon={faNoteSticky} displayText="Notes"></NavItem>
+          <NavItem icon={faGear} displayText="Settings"></NavItem>
+          <NavItem
+            icon={faPowerOff}
+            displayText="Logout"
+            onClick={logoutUser}
+          ></NavItem>
+        </div>
+      </Border>
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/src/components/modal/AlertModal.tsx
+++ b/src/components/modal/AlertModal.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "react-query";
-import Border from "../ui/branding/Border";
+import Border from "../ui/Border";
 
 interface Props {
   message: string;

--- a/src/components/ui/Border.tsx
+++ b/src/components/ui/Border.tsx
@@ -5,14 +5,16 @@ interface Props {
   children: ReactNode;
   highlight?: boolean;
   shadow?: boolean;
+  borderRadius?: boolean;
 }
 
-function Border({ children, highlight, shadow }: Props) {
+function Border({ children, borderRadius = true, highlight, shadow }: Props) {
   const cx = classNames(
+    "h-inherit",
     "relative",
-    "border-rd-10px",
-    "outline-solid",
     "overflow-hidden",
+    "outline-solid",
+    { "border-rd-10px": borderRadius },
     { "outline-color-brand outline-1px": !highlight },
     { "outline-brand-secundary-300 outline-2px": highlight },
     { "shadow-brand": shadow }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import Border from "./branding/Border";
+import Border from "./Border";
 
 interface Props {
   value: string;

--- a/src/components/ui/InputText.tsx
+++ b/src/components/ui/InputText.tsx
@@ -1,7 +1,7 @@
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ChangeEvent, useState } from "react";
-import Border from "./branding/Border";
+import Border from "./Border";
 
 interface Props {
   type: "text" | "password";

--- a/src/components/ui/NavItem.tsx
+++ b/src/components/ui/NavItem.tsx
@@ -1,0 +1,19 @@
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface Props {
+  icon: IconDefinition;
+  displayText: string;
+  onClick?: () => void;
+}
+
+function NavItem({ icon, displayText, onClick }: Props) {
+  return (
+    <div className="flex gap-2 cursor-pointer hover:text-brand-secundary-300">
+      <FontAwesomeIcon icon={icon} />
+      <a onClick={onClick}>{displayText}</a>
+    </div>
+  );
+}
+
+export default NavItem;

--- a/src/components/ui/textArea.tsx
+++ b/src/components/ui/textArea.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from "react";
+import Border from "./Border";
 
 interface Props {
   name: string;
@@ -9,14 +10,16 @@ interface Props {
 
 function TextArea({ name, value, placeholder, onChange }: Props) {
   return (
-    <textarea
-      placeholder={placeholder}
-      rows={20}
-      className="border-brand p-5.5 w-410px resize-none border-rd-5px font-primary font-size-normal focus:outline-brand-secundary-300"
-      name={name}
-      onChange={onChange}
-      value={value}
-    ></textarea>
+    <Border sides="ALL">
+      <textarea
+        placeholder={placeholder}
+        rows={20}
+        className=" border-none outline-none border-brand p-5.5 w-410px resize-none border-rd-5px font-primary font-size-normal focus:outline-brand-secundary-300"
+        name={name}
+        onChange={onChange}
+        value={value}
+      ></textarea>
+    </Border>
   );
 }
 

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -26,6 +26,7 @@ export function AuthProvider({ children }: Props) {
     });
 
     if (error) {
+      setLoading(false);
       throw error;
     }
 
@@ -55,6 +56,7 @@ export function AuthProvider({ children }: Props) {
   function registerUser() {}
 
   async function logoutUser() {
+    console.log("logout user called");
     try {
       await supabase.auth.signOut({ scope: "local" });
       setUser(undefined);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,14 +2,19 @@ import Note from "@src/components/NoteCard";
 import Heading from "@components/Heading";
 import Footer from "@components/Footer";
 import NoteEditModal from "@src/components/modal/NoteEditModal";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNotes } from "@src/hooks/useNotes";
 import { NoteRow } from "@src/types";
 import { useQuery } from "react-query";
+import Sidebar from "@src/components/Sidebar";
+import classNames from "classnames";
+import { useCookies } from "react-cookie";
 
 function Home() {
   const [isNoteEditOpen, setNoteEditOpen] = useState(false);
+  const [isSideNavOpen, setIsSideNavOpen] = useState(false);
   const { notes, clearCurrentNote, fetchNotes } = useNotes();
+  const [cookies, setCookie] = useCookies(["defaultSideNavOpenState"]);
 
   /** FETCH NOTES TO NOTES CONTEXT WITH REACT-QUERY*/
   const notesQuery = useQuery({
@@ -17,29 +22,54 @@ function Home() {
     queryKey: ["notes"],
   });
 
+  useEffect(() => {
+    setIsSideNavOpen(cookies.defaultSideNavOpenState);
+  }, [cookies.defaultSideNavOpenState]);
+
   if (notesQuery.isLoading) {
     return <div>Loading...</div>;
   }
 
+  const pageStyle = classNames(
+    "flex",
+    "flex-col",
+    "min-h-100vh",
+    "transition-margin-300",
+    {
+      "ml-200px": isSideNavOpen,
+      "ml-0": !isSideNavOpen,
+    }
+  );
+
   // on query completed
   return (
     <>
-      <div className="h-100vh flex flex-col">
-        <Heading position="sticky" openModal={() => setNoteEditOpen(true)} />
-        <div>
-          <div className="my-10 mx-10% flex flex-wrap gap-lg justify-center font-primary">
-            {notes.length > 0 &&
-              notes.map((note: NoteRow) => (
-                <Note
-                  key={note.id}
-                  note={note}
-                  openNoteEdit={() => setNoteEditOpen(true)}
-                />
-              ))}
-          </div>
+      <div className={pageStyle}>
+        <Heading
+          openModal={() => setNoteEditOpen(true)}
+          sideNaveToggleIcon={true}
+          openSideNav={() => setIsSideNavOpen(true)}
+          sideNavOpen={isSideNavOpen}
+        />
+        <div className="mt-10 mb-auto mx-10% flex flex-wrap gap-lg justify-center font-primary">
+          {notes.length > 0 &&
+            notes.map((note: NoteRow) => (
+              <Note
+                key={note.id}
+                note={note}
+                openNoteEdit={() => setNoteEditOpen(true)}
+              />
+            ))}
         </div>
         <Footer />
       </div>
+
+      <Sidebar
+        defaultSideNavOpenState={cookies.defaultSideNavOpenState}
+        setDefaultSideNavOpenState={setDefaultSideNavOpenState}
+        isOpen={isSideNavOpen}
+        closeNav={() => setIsSideNavOpen(false)}
+      />
 
       <NoteEditModal
         isOpen={isNoteEditOpen}
@@ -50,6 +80,13 @@ function Home() {
       />
     </>
   );
+
+  function setDefaultSideNavOpenState() {
+    setCookie(
+      "defaultSideNavOpenState",
+      cookies.defaultSideNavOpenState ? !cookies.defaultSideNavOpenState : true
+    );
+  }
 }
 
 export default Home;

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -43,10 +43,11 @@ export default defineConfig({
       getCSS: () => `
       body{
         margin: 0;
+        background-color: #ccc;
+        color: #122D36;
       }
 
       #root {
-        background-color: #ccc;
         padding: 0;
         margin: 0;
         display: flex;
@@ -62,7 +63,6 @@ export default defineConfig({
       {
         "box-shadow": "0 2px 5px #ccc",
         "background-color": "#fff",
-        color: "#023047ff",
       },
     ],
     [


### PR DESCRIPTION
side navigation can be toggled from the header and closed from inside the components the default open-closed state can also be toggled and is stored as cookie for user preference

navigation elements:
-link to notes pages (not yet active, implementation in later ticket) -link to settings pages (not yet active, implementation in later ticket) -logout functionality

BREAKING CHANGE: the logout functionality has been moved from header to side navigation